### PR TITLE
explicitely cast to uint8 in order to prevent data loss

### DIFF
--- a/kaggle_dsb18/kaggle_dsb18_preprocessing.py
+++ b/kaggle_dsb18/kaggle_dsb18_preprocessing.py
@@ -1,7 +1,7 @@
 import os
 import numpy as np
 
-from skimage import io
+from skimage import io, img_as_ubyte
 
 from shutil import copy
 from collections import Container
@@ -38,7 +38,7 @@ def merge_masks(masks_folder):
     merged_mask = np.sum(masks, axis=0)
     merged_mask[merged_mask > 0] = 1
 
-    return merged_mask
+    return img_as_ubyte(merged_mask)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
recent versions of skimage apply an automated scaling from uint64 to
uint8 which effectively removes the `1`s that mimick the mask in `kaggle_dsb18_preprocessing.py`

see https://github.com/scikit-image/scikit-image/issues/4509