### PR TITLE
fix: activation for last layer of UNet2D

### DIFF
--- a/unet/blocks.py
+++ b/unet/blocks.py
@@ -123,8 +123,10 @@ class Last2D(nn.Module):
             nn.BatchNorm2d(middle_channels),
             nn.ReLU(inplace=True),
             nn.Conv2d(middle_channels, out_channels, kernel_size=1),
-            nn.Softmax(dim=1)
         ]
+
+        if softmax:
+            layers.append(nn.Softmax(dim=1))
 
         self.first = nn.Sequential(*layers)
 

--- a/unet/unet.py
+++ b/unet/unet.py
@@ -21,7 +21,7 @@ class UNet2D(nn.Module):
         decoder_layers = []
         decoder_layers.extend([Decoder2D(2 * conv_depths[i + 1], 2 * conv_depths[i], 2 * conv_depths[i], conv_depths[i])
                                for i in reversed(range(len(conv_depths)-2))])
-        decoder_layers.append(Last2D(conv_depths[1], conv_depths[0], out_channels))
+        decoder_layers.append(Last2D(2*conv_depths[0], conv_depths[0], out_channels))
 
         # encoder, center and decoder layers
         self.encoder_layers = nn.Sequential(*encoder_layers)


### PR DESCRIPTION
Softmax was being applied by default to the output of the Last2D block, and the `softmax` argument in the forward method was unused.
Fixed it to use the argument to append a softmax layer only when the argument is True.

Last2D expects wrong input channels, only works when conv depths are multiplied by 2 at each depth. Fixed it to work when this condition does not hold.